### PR TITLE
Update Omnigraffle version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,6 @@
 class omnigraffle {
   package { 'OmniGraffle':
     provider => 'appdmg_eula',
-    source   => 'http://downloads2.omnigroup.com/software/MacOSX/10.8/OmniGraffle-6.0.dmg'
+    source   => 'http://downloads2.omnigroup.com/software/MacOSX/10.8/OmniGraffle-6.0.2.dmg'
   }
 }

--- a/spec/classes/omnigraffle_spec.rb
+++ b/spec/classes/omnigraffle_spec.rb
@@ -4,6 +4,6 @@ describe 'omnigraffle' do
 
   it { should contain_class('omnigraffle') }
   it { should contain_package('OmniGraffle').with_provider('appdmg_eula') }
-  it { should contain_package('OmniGraffle').with_source('http://downloads2.omnigroup.com/software/MacOSX/10.8/OmniGraffle-6.0.dmg') }
+  it { should contain_package('OmniGraffle').with_source('http://downloads2.omnigroup.com/software/MacOSX/10.8/OmniGraffle-6.0.2.dmg') }
 
 end


### PR DESCRIPTION
6.0 has been removed from the Omnigroup. This PR bumps the version to 6.0.2
